### PR TITLE
Add support for micro:bit V2.

### DIFF
--- a/Adafruit_Microbit.cpp
+++ b/Adafruit_Microbit.cpp
@@ -36,9 +36,13 @@
  *
  */
 
-#include "nrf_soc.h"
 #include <Adafruit_Microbit.h>
 
+#ifdef SD_SELECTED
+#include "nrf_soc.h"
+#endif
+
+#if defined(NRF51)
 #define MATRIX_ROWS 3 //!< Number of rows on the microbit LED matrix
 #define MATRIX_COLS 9 //!< Number of columns on the microbit LED matrix
 uint8_t rowpins[MATRIX_ROWS] = {
@@ -55,6 +59,23 @@ uint8_t pixel_to_col[25] = {
     1, 4, 2, 5, 3, 4, 5, 6, 7, 8, 2, 9, 3,
     9, 1, 8, 7, 6, 5, 4, 3, 7, 1, 6, 2}; //!< Defines what column each pixel is
                                          //!< in
+#elif defined(NRF52833_XXAA)
+#define MATRIX_ROWS 5 //!< Number of rows on the microbit LED matrix
+#define MATRIX_COLS 5 //!< Number of columns on the microbit LED matrix
+uint8_t rowpins[MATRIX_ROWS] = {
+    21, 22, 23, 24,
+    25}; //!< Pin numbers for the rows on the microbit LED matrix
+uint8_t colpins[MATRIX_COLS] = {
+    4, 7, 3, 6, 10}; //!< Pin numbers for the columns on the microbit LED matrix
+
+uint8_t pixel_to_row[25] = {
+    1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3,
+    3, 3, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5}; //!< Defines what row each pixel is in
+
+uint8_t pixel_to_col[25] = {
+    1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 1, 2, 3, 4, 5,
+}; //!< Defines what column each pixel is in
+#endif
 
 volatile uint8_t currentRow =
     0; //!< Iterator that is used to write to the desired row
@@ -400,6 +421,7 @@ void Adafruit_Microbit_Matrix::scrollText(char *string, uint8_t stepdelay) {
  */
 void Adafruit_Microbit::begin(void) { matrix.begin(); }
 
+#ifdef SD_SELECTED
 /*!
  *    @brief  Request the temperature from the Soft Device
  *    @returns Temperature in Celsius
@@ -418,9 +440,10 @@ uint8_t Adafruit_Microbit::getDieTemp(void) {
 
   return temp / 4;
 }
+#endif
 
 /*********************************************************************/
-
+#ifdef SD_SELECTED
 Adafruit_Microbit_BLESerial *Adafruit_Microbit_BLESerial::_instance = NULL;
 
 /*!
@@ -600,7 +623,7 @@ void Adafruit_Microbit_BLESerial::_received(
   Adafruit_Microbit_BLESerial::_instance->_received(
       rxCharacteristic.value(), rxCharacteristic.valueLength());
 }
-
+#endif
 /*************************************************************************************************/
 
 /*!

--- a/Adafruit_Microbit.h
+++ b/Adafruit_Microbit.h
@@ -7,8 +7,12 @@
 
 #include <Adafruit_GFX.h>
 #include <Arduino.h>
-#include <BLEPeripheral.h>
 #include <Fonts/TomThumb.h>
+
+#if defined(S110) || defined(S130)
+#define SD_SELECTED
+#include <BLEPeripheral.h>
+#endif
 
 #define LED_ON 1  //!< Used to make turning the LED on more readable
 #define LED_OFF 0 //!< Used to make turning the LED off more readable
@@ -37,10 +41,14 @@ public:
 
 private:
   void startTimer();
-
+#if defined(NRF51)
   uint8_t matrix_buffer[3][9];
+#elif defined(NRF52833_XXAA)
+  uint8_t matrix_buffer[5][5];
+#endif
 };
 
+#ifdef SD_SELECTED
 /** Class to use Nordic UART service as a Stream object on micro:bit */
 class Adafruit_Microbit_BLESerial : public BLEPeripheral, public Stream {
 public:
@@ -88,15 +96,17 @@ private:
   static void _received(BLECentral & /*central*/,
                         BLECharacteristic &rxCharacteristic);
 };
+#endif
 
 /** Class to create hardware interface to BLE/matrix of micro:bit */
 class Adafruit_Microbit {
 public:
-  Adafruit_Microbit_Matrix matrix;        ///< 5x5 graphical matrix
+  Adafruit_Microbit_Matrix matrix; ///< 5x5 graphical matrix
+#ifdef SD_SELECTED
   Adafruit_Microbit_BLESerial BTLESerial; ///< Nordic UART service connection
+  uint8_t getDieTemp(void);
+#endif
 
   void begin(void);
-
-  uint8_t getDieTemp(void);
 };
 #endif


### PR DESCRIPTION
- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.** 

This PR adds support for micro:bit V2, which has a different LED matrix arrangement.

Because V2 currently has no support for SoftDevice in https://github.com/sandeepmistry/arduino-nRF5 I had to do conditional compilation for the BLE and SoftDevice (`getDieTemp` method) parts.

It basically checks if one of these two options are selected:
<img width="490" alt="image" src="https://user-images.githubusercontent.com/4189262/124510464-c51c5500-ddcb-11eb-8028-76671a3cc394.png">



- **Describe any known limitations with your change.** 

Because the BLE specific code is defined out if no SoftDevice is selected in the Arduino IDE, some of the examples might fail to compile until an option is selected.

- **Please run any tests or examples that can exercise your modified code.** 

I've run the following examples successfully on a micro:bit V1 and V2:
- button demo
- matrix demo

The following examples use micro:bit V1 specific pins:
- blink demo
- timer demo

The rest are BLE examples and I've tested that they compile for V1.
