### PR TITLE
Fix MICROBIT_SMILE and remove matrix_buffer double init

### DIFF
--- a/Adafruit_Microbit.cpp
+++ b/Adafruit_Microbit.cpp
@@ -606,8 +606,9 @@ void Adafruit_Microbit_BLESerial::_received(
 /*!
  * @brief Preset smile image for LED matrix
  */
-const uint8_t MICROBIT_SMILE[5] = {B00000000, B01010000, B00000000, B10001000,
-                                   B01110000};
+const uint8_t Adafruit_Microbit_Matrix::MICROBIT_SMILE[5] = {
+    B00000, B01010, B00000, B10001, B01110,
+};
 
 const uint8_t Adafruit_Microbit_Matrix::EMPTYHEART[5] = {
     B01010, B10101, B10001, B01010, B00100,

--- a/Adafruit_Microbit.h
+++ b/Adafruit_Microbit.h
@@ -33,7 +33,8 @@ public:
   static const uint8_t EMPTYHEART[5], ///< an empty heart icon
       HEART[5],                       ///< full heart icon
       NO[5],                          ///< X icon
-      YES[5];                         ///< Check icon
+      YES[5],                         ///< Check icon
+      MICROBIT_SMILE[5];              ///< smile icon
 
 private:
   void startTimer();


### PR DESCRIPTION
- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**

Just a couple of things I noticed while working on https://github.com/adafruit/Adafruit_Microbit/pull/12, as they are not V2 specific I've added them as separate PR:

 Fixed MICROBIT_SMILE and added as public icon.
 Remove the second matrix_buffer initialisation, as it is already zero out in the Adafruit_Microbit_Matrix constructor.

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.

N/A

- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process.

Run the matrix example and edit it to also show the new smile icon.
