### PR TITLE
Set device name before BTLESerial.begin

### DIFF
--- a/examples/ble_controller/ble_controller.ino
+++ b/examples/ble_controller/ble_controller.ino
@@ -24,8 +24,8 @@ void setup() {
   Serial.println("Controller demo ready!");
 
   // custom services and characteristics can be added as well
-  microbit.BTLESerial.begin();
   microbit.BTLESerial.setLocalName("microbit");
+  microbit.BTLESerial.begin();
 
   // Start LED matrix driver after radio (required)
   microbit.begin();

--- a/examples/ble_dietemp/ble_dietemp.ino
+++ b/examples/ble_dietemp/ble_dietemp.ino
@@ -10,8 +10,8 @@ void setup()
   
   Serial.println("nRF5x Die Temperature Plotting");
 
-  microbit.BTLESerial.begin();
   microbit.BTLESerial.setLocalName("microbit");
+  microbit.BTLESerial.begin();
 
   // Start LED matrix driver after radio (required)
   microbit.begin();

--- a/examples/ble_plotterdemo/ble_plotterdemo.ino
+++ b/examples/ble_plotterdemo/ble_plotterdemo.ino
@@ -19,8 +19,8 @@ void setup() {
   accel.begin(false, 2); // 8-bit mode, 2g range
     
   // custom services and characteristics can be added as well
-  microbit.BTLESerial.begin();
   microbit.BTLESerial.setLocalName("microbit");
+  microbit.BTLESerial.begin();
 
   // Start LED matrix driver after radio (required)
   microbit.begin();

--- a/examples/ble_uartdemo/ble_uartdemo.ino
+++ b/examples/ble_uartdemo/ble_uartdemo.ino
@@ -24,8 +24,8 @@ void setup() {
   Serial.println("Microbit ready!");
   
   // custom services and characteristics can be added as well
-  microbit.BTLESerial.begin();
   microbit.BTLESerial.setLocalName("microbit");
+  microbit.BTLESerial.begin();
 
   // Start LED matrix driver after radio (required)
   microbit.begin();


### PR DESCRIPTION
When I tried the examples that come with this library my phone's bluetooth settings (and the Bluefruit app) only identified the micro:bit by its MAC address, not the "microbit" name which is set in the examples. In the examples, the code looks like this:

```c
microbit.BTLESerial.begin();
microbit.BTLESerial.setLocalName("microbit");
```

i.e. it sets up the bluetooth radio and then sets the name to "microbit". 

The BLEPeripheral library's documentation isn't clear, but its examples call `.begin()` *after* setting the name and attributes:

```c
  blePeripheral.setLocalName("remote-attributes");


  // set device name and appearance
  blePeripheral.setDeviceName("Remote Attributes");
  blePeripheral.setAppearance(0x0080);


  blePeripheral.addRemoteAttribute(remoteGenericAttributeService);
  blePeripheral.addRemoteAttribute(remoteDeviceNameCharacteristic);


  // assign event handlers for connected, disconnected to peripheral
  blePeripheral.setEventHandler(BLEConnected, blePeripheralConnectHandler);
  blePeripheral.setEventHandler(BLEDisconnected, blePeripheralDisconnectHandler);
  blePeripheral.setEventHandler(BLERemoteServicesDiscovered, blePeripheralRemoteServicesDiscoveredHandler);


  // assign event handlers for characteristic
  remoteDeviceNameCharacteristic.setEventHandler(BLEValueUpdated, bleRemoteDeviceNameCharacteristicValueUpdatedHandle);


  // begin initialization
  blePeripheral.begin();
```

https://github.com/sandeepmistry/arduino-BLEPeripheral/blob/161a4163f565be3cd5b62bbc59f0c2b522d82b02/examples/remote_service/remote_service.ino#L24-L42

I tried changing the order so it's:

```c
microbit.BTLESerial.begin();
microbit.BTLESerial.setLocalName("microbit");
```

and my phone now shows "microbit" instead of the MAC address, which I assume is the intention?.
